### PR TITLE
Initial support for global project enumeration

### DIFF
--- a/backend/controllers/projects-controller.go
+++ b/backend/controllers/projects-controller.go
@@ -60,6 +60,45 @@ func RetrieveProject(c *gin.Context) {
 	c.JSON(http.StatusOK, response)
 }
 
+type ProjectListResponse struct {
+    Projects []ProjectRetrievalResponse `json:"projects"`
+}
+
+// ListProjects godoc
+// @Summary      List all research projects
+// @Description  Retrieves a list of all research projects
+// @Tags         Projects
+// @Accept       json
+// @Produce      json
+// @Success      200 {object} ProjectListResponse
+// @Failure      500 {object} ErrorResponse
+// @Router       /projects [get]
+func ListProjects(c *gin.Context) {
+    var projects []models.Project
+    
+    // Fetch all projects with their owners
+    if err := database.DB.Find(&projects).Error; err != nil {
+        c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to fetch projects"})
+        return
+    }
+
+    // Convert to response format
+    response := make([]ProjectRetrievalResponse, len(projects))
+    for i, project := range projects {
+        response[i] = ProjectRetrievalResponse{
+            ID:             project.ID,
+            Title:          project.Title,
+            Description:    project.Description,
+            RequiredSkills: project.GetRequiredSkills(),
+            Visibility:     project.Visibility,
+            Status:        project.Status,
+            OwnerID:       project.OwnerID,
+        }
+    }
+
+    c.JSON(http.StatusOK, ProjectListResponse{Projects: response})
+}
+
 type ProjectCreationRequest struct {
 	Title          string   `json:"title" binding:"required"`
 	Description    string   `json:"description"`

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -114,6 +114,33 @@ const docTemplate = `{
             }
         },
         "/projects": {
+            "get": {
+                "description": "Retrieves a list of all research projects",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Projects"
+                ],
+                "summary": "List all research projects",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.ProjectListResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.ErrorResponse"
+                        }
+                    }
+                }
+            },
             "post": {
                 "description": "Creates a new research project and assigns the creator as an owner",
                 "consumes": [
@@ -414,6 +441,17 @@ const docTemplate = `{
                 "message": {
                     "type": "string",
                     "example": "Project successfully created"
+                }
+            }
+        },
+        "controllers.ProjectListResponse": {
+            "type": "object",
+            "properties": {
+                "projects": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/controllers.ProjectRetrievalResponse"
+                    }
                 }
             }
         },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -107,6 +107,33 @@
             }
         },
         "/projects": {
+            "get": {
+                "description": "Retrieves a list of all research projects",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Projects"
+                ],
+                "summary": "List all research projects",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.ProjectListResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.ErrorResponse"
+                        }
+                    }
+                }
+            },
             "post": {
                 "description": "Creates a new research project and assigns the creator as an owner",
                 "consumes": [
@@ -407,6 +434,17 @@
                 "message": {
                     "type": "string",
                     "example": "Project successfully created"
+                }
+            }
+        },
+        "controllers.ProjectListResponse": {
+            "type": "object",
+            "properties": {
+                "projects": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/controllers.ProjectRetrievalResponse"
+                    }
                 }
             }
         },

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -62,6 +62,13 @@ definitions:
         example: Project successfully created
         type: string
     type: object
+  controllers.ProjectListResponse:
+    properties:
+      projects:
+        items:
+          $ref: '#/definitions/controllers.ProjectRetrievalResponse'
+        type: array
+    type: object
   controllers.ProjectRetrievalResponse:
     properties:
       description:
@@ -188,6 +195,24 @@ paths:
       tags:
       - Authentication
   /projects:
+    get:
+      consumes:
+      - application/json
+      description: Retrieves a list of all research projects
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/controllers.ProjectListResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/controllers.ErrorResponse'
+      summary: List all research projects
+      tags:
+      - Projects
     post:
       consumes:
       - application/json

--- a/backend/routes/projects-routes.go
+++ b/backend/routes/projects-routes.go
@@ -10,6 +10,7 @@ import (
 func ProjectsRoutes(router *gin.Engine) {
 	projects := router.Group("/projects")
 	{
+		projects.GET("", controllers.ListProjects)
 		projects.POST("", middleware.AuthRequired(), controllers.CreateProject)
 		projects.GET("/:id", controllers.RetrieveProject)
 	}


### PR DESCRIPTION
**Note**: Ideally, a user (authenticated or not) should only be able to retrieve those projects that have been marked as publicly visible. We leave this detail to a future commit.